### PR TITLE
ubu-chroot: Allow Ubuntu 20.04 LTS (Focal Fossa)

### DIFF
--- a/mer-android-chroot
+++ b/mer-android-chroot
@@ -298,8 +298,8 @@ do_it_all() {
 	    if grep squeeze ${uburoot}/etc/debian_version > /dev/null; then
 		# For older 10.04
 		setarch x86_64 chroot ${uburoot} /usr/bin/sudo -i -u $user "export MERSDKUBU=1; if [ -d \"$cwd\" ]; then cd \"$cwd\"; fi; exec bash --init-file /parentroot/usr/share/ubu-chroot/mer-ubusdk-bash-setup -i";
-	    elif grep "wheezy\|jessie" ${uburoot}/etc/debian_version > /dev/null; then
-		# This is for ubuntu 12.04 (arg quoting for sudo is different)
+	    elif grep -w "wheezy\|jessie\|bullseye\|sid" ${uburoot}/etc/debian_version > /dev/null; then
+		# This is for ubuntu 12.04+ (arg quoting for sudo is different)
 		setarch x86_64 chroot ${uburoot} /usr/bin/sudo -i -u $user exec bash -i -c "export MERSDKUBU=1; if [ -d \"$cwd\" ]; then cd \"$cwd\"; fi; exec bash --init-file /parentroot/usr/share/ubu-chroot/mer-ubusdk-bash-setup"
 	    else
 		echo Unknown ubuntu version


### PR DESCRIPTION
First needs ubu-focal tarball made available under https://releases.sailfishos.org/ubu/