### PR TITLE
[ubu-chroot] Disable pam account management for sudo. Fixes JB#57353

### DIFF
--- a/mer-android-chroot
+++ b/mer-android-chroot
@@ -296,7 +296,7 @@ do_it_all() {
     case "$#" in
 	0 )
 	    inform "Entering chroot as $user"
-	    if grep squeeze ${uburoot}/etc/debian_version > /dev/null; then
+	    if grep -q squeeze ${uburoot}/etc/debian_version; then
 		# For older 10.04
 		setarch x86_64 chroot ${uburoot} /usr/bin/sudo -i -u $user "export MERSDKUBU=1; if [ -d \"$cwd\" ]; then cd \"$cwd\"; fi; exec bash --init-file /parentroot/usr/share/ubu-chroot/mer-ubusdk-bash-setup -i";
 	    elif grep -w "wheezy\|jessie\|bullseye\|sid" ${uburoot}/etc/debian_version > /dev/null; then

--- a/mer-android-chroot
+++ b/mer-android-chroot
@@ -88,7 +88,7 @@ bind_mount_home="yes";
 
 QUIET=yes
 
-while getopts "u:m:r:v" opt; do
+while getopts "u:m:r:vh" opt; do
     case $opt in
 	u ) user=$OPTARG;;
 	m )

--- a/mer-android-chroot
+++ b/mer-android-chroot
@@ -245,7 +245,12 @@ prepare_user() {
 	inform "mount --rbind ${proot}${HOMEDIR} ${uburoot}${HOMEDIR}"
 	mount --rbind ${proot}${HOMEDIR} ${uburoot}${HOMEDIR}
     fi
-    echo "$user ALL=NOPASSWD: ALL" > ${uburoot}/etc/sudoers.d/$user
+    cat > ${uburoot}/etc/sudoers.d/$user <<EOF
+$user ALL=NOPASSWD: ALL
+# With newer sudo versions we need to disable pam_acct_mgmt since it
+# does't work for our use case and there's no use for it in the ubuntu-chroot.
+Defaults !pam_acct_mgmt
+EOF
     chmod 0440 ${uburoot}/etc/sudoers.d/$user
 }
 

--- a/mer-android-chroot
+++ b/mer-android-chroot
@@ -71,7 +71,8 @@ fi
 
 if cmp -s /proc/$PPID/mountinfo /proc/self/mountinfo; then
     # Propagation switch was introduced by util-linux-2.27, let's check here:
-    unshare --help | fgrep -q -- --propagation && UNSHARE_EXTRA_OPT="--propagation unchanged"
+    unshare --help | grep -F -q \
+                          -- --propagation && UNSHARE_EXTRA_OPT="--propagation unchanged"
     # Leave the propagation unchanged when launched within SDK, otherwise an
     # attempt to alter it (even default behaviour) results in "Invalid argument"
     exec unshare $UNSHARE_EXTRA_OPT -m -- "$0" "$@"


### PR DESCRIPTION
With newer sudo versions we need to disable pam_acct_mgmt since it
does't work for our use case and there's no use for it in the
ubuntu-chroot.

Read: man sudoers 5