### PR TITLE
mer-android-chroot: use !fqdn in sudoers

### DIFF
--- a/mer-android-chroot
+++ b/mer-android-chroot
@@ -250,6 +250,8 @@ $user ALL=NOPASSWD: ALL
 # With newer sudo versions we need to disable pam_acct_mgmt since it
 # does't work for our use case and there's no use for it in the ubuntu-chroot.
 Defaults !pam_acct_mgmt
+# Don't bother trying to resolve the hostname
+Defaults !fqdn
 EOF
     chmod 0440 ${uburoot}/etc/sudoers.d/$user
 }


### PR DESCRIPTION
this avoids "sudo: unable to resolve host ..." warnings.